### PR TITLE
Support local admin extensions to config file

### DIFF
--- a/update-crypto-policies
+++ b/update-crypto-policies
@@ -5,6 +5,7 @@ umask 022
 profile_dir=/usr/share/crypto-policies/profiles
 base_dir=/etc/crypto-policies
 backend_config_dir=$base_dir/back-ends
+local_config_dir=$base_dir/local.d
 state_dir=$base_dir/state
 errcode=0
 nocheck=0
@@ -45,13 +46,21 @@ fi
 mkdir -p $backend_config_dir >/dev/null 2>&1
 mkdir -p $state_dir >/dev/null 2>&1
 
-gnutls_config_file=$backend_config_dir/gnutls.config
-gnutls28_config_file=$backend_config_dir/gnutls28.config
-openssl_config_file=$backend_config_dir/openssl.config
-nss_config_file=$backend_config_dir/nss.config
-bind_config_file=$backend_config_dir/bind.config
-java_config_file=$backend_config_dir/java.config
-krb5_config_file=$backend_config_dir/krb5.config
+gnutls_config_name=gnutls.config
+gnutls28_config_name=gnutls28.config
+openssl_config_name=openssl.config
+nss_config_name=nss.config
+bind_config_name=bind.config
+java_config_name=java.config
+krb5_config_name=krb5.config
+
+gnutls_config_file=$backend_config_dir/$gnutls_config_name
+gnutls28_config_file=$backend_config_dir/$gnutls28_config_name
+openssl_config_file=$backend_config_dir/$openssl_config_name
+nss_config_file=$backend_config_dir/$nss_config_name
+bind_config_file=$backend_config_dir/$bind_config_name
+java_config_file=$backend_config_dir/$java_config_name
+krb5_config_file=$backend_config_dir/$krb5_config_name
 
 profile=$(cat $base_dir/config|grep -v ^#)
 
@@ -95,8 +104,11 @@ fi
 . "$profile_dir/$profile"
 
 create_config () {
-	target=$1
+	config=$1
 	content=$2
+
+	target=$backend_config_dir/$config.tmp
+	local=$local_config_dir/$config
 
 	touch $target >/dev/null 2>&1
 	if ! test -f $target;then
@@ -104,16 +116,20 @@ create_config () {
 		exit 1
 	fi
 	echo -e "$content" > $target
+
+	if test -e $local; then
+		cat $local >> $target
+	fi
 }
 
 # Generate policies
-create_config $gnutls_config_file.tmp "$CONFIG_GNUTLS"
-create_config $gnutls28_config_file.tmp "$CONFIG_GNUTLS28"
-create_config $bind_config_file.tmp "$CONFIG_BIND"
-create_config $java_config_file.tmp "$CONFIG_JAVA"
-create_config $openssl_config_file.tmp "$CONFIG_OPENSSL"
-create_config $nss_config_file.tmp "$CONFIG_NSS"
-create_config $krb5_config_file.tmp "$CONFIG_KRB5"
+create_config $gnutls_config_name "$CONFIG_GNUTLS"
+create_config $gnutls28_config_name "$CONFIG_GNUTLS28"
+create_config $bind_config_name "$CONFIG_BIND"
+create_config $java_config_name "$CONFIG_JAVA"
+create_config $openssl_config_name "$CONFIG_OPENSSL"
+create_config $nss_config_name "$CONFIG_NSS"
+create_config $krb5_config_name "$CONFIG_KRB5"
 
 # Test policies
 if test nocheck = 0 && test -x /usr/bin/gnutls-cli;then

--- a/update-crypto-policies
+++ b/update-crypto-policies
@@ -94,15 +94,28 @@ fi
 
 . "$profile_dir/$profile"
 
-# Generate policy for GnuTLS
-touch $gnutls_config_file.tmp >/dev/null 2>&1
-if ! test -f $gnutls_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-echo -e "$CONFIG_GNUTLS" > $gnutls_config_file.tmp
+create_config () {
+	target=$1
+	content=$2
 
-# Test policy
+	touch $target >/dev/null 2>&1
+	if ! test -f $target;then
+		echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
+		exit 1
+	fi
+	echo -e "$content" > $target
+}
+
+# Generate policies
+create_config $gnutls_config_file.tmp "$CONFIG_GNUTLS"
+create_config $gnutls28_config_file.tmp "$CONFIG_GNUTLS28"
+create_config $bind_config_file.tmp "$CONFIG_BIND"
+create_config $java_config_file.tmp "$CONFIG_JAVA"
+create_config $openssl_config_file.tmp "$CONFIG_OPENSSL"
+create_config $nss_config_file.tmp "$CONFIG_NSS"
+create_config $krb5_config_file.tmp "$CONFIG_KRB5"
+
+# Test policies
 if test nocheck = 0 && test -x /usr/bin/gnutls-cli;then
 	gnutls-cli -l --priority `cat $gnutls_config_file.tmp|sed 's/SYSTEM=//g'` >/dev/null 2>&1
 	if test $? != 0;then
@@ -112,37 +125,6 @@ if test nocheck = 0 && test -x /usr/bin/gnutls-cli;then
 	fi
 fi
 
-# Generate policy for compat-gnutls28
-touch $gnutls28_config_file.tmp >/dev/null 2>&1
-if ! test -f $gnutls28_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-echo -e "$CONFIG_GNUTLS28" > $gnutls28_config_file.tmp
-
-# Generate policy for openssl
-touch $openssl_config_file.tmp >/dev/null 2>&1
-if ! test -f $openssl_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-echo -e "$CONFIG_OPENSSL" > $openssl_config_file.tmp 2>&1
-
-# Generate policy for NSS
-echo -e "$CONFIG_NSS" > $nss_config_file.tmp 2>&1
-if ! test -f $nss_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-
-# Generate policy for krb5
-echo -e "$CONFIG_KRB5" > $krb5_config_file.tmp 2>&1
-if ! test -f $krb5_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-
-# Test policies
 if test nocheck = 0 && test -x /usr/bin/openssl;then
 	openssl ciphers `cat $openssl_config_file.tmp` >/dev/null 2>&1
 	if test $? != 0;then
@@ -152,22 +134,6 @@ if test nocheck = 0 && test -x /usr/bin/openssl;then
 	fi
 fi
 
-# Generate policy for bind
-touch $bind_config_file.tmp >/dev/null 2>&1
-if ! test -f $bind_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-echo -e "$CONFIG_BIND" > $bind_config_file.tmp 2>&1
-
-touch $java_config_file.tmp >/dev/null 2>&1
-if ! test -f $java_config_file.tmp;then
-	echo "Cannot write to $backend_config_dir. This program requires administrator permissions."
-	exit 1
-fi
-echo -e "$CONFIG_JAVA" > $java_config_file.tmp 2>&1
-
-# Test policies
 if test nocheck = 0 && test -x /usr/sbin/named-checkconf;then
 	/usr/sbin/named-checkconf >/dev/null 2>&1
 	if test $? != 0;then

--- a/update-crypto-policies.8.txt
+++ b/update-crypto-policies.8.txt
@@ -133,6 +133,9 @@ FILES
 /etc/crypto-policies/back-ends::
 	Contains the generated policies in separated files, and in a format readable by the supported back-ends.
 
+/etc/crypto-policies/local.d::
+	Contains local administrator additions, which are directly appended to the back-end config files when updated. The file names in this directory should match those in the back-ends directory and their content be in the back-end specific format.
+
 AUTHOR
 ------
 Written by Nikos Mavrogiannopoulos.


### PR DESCRIPTION
This is particularly useful in combination with this proposed gnutls patch:

http://lists.gnutls.org/pipermail/gnutls-devel/2016-June/008007.html

though even with existing released gnutls versions, it would still be beneficial.