### PR TITLE
allow local administrator extensions to the back-end config 

### DIFF
--- a/back-ends/gnutls.pl
+++ b/back-ends/gnutls.pl
@@ -193,6 +193,7 @@ sub generate_temp_policy() {
 		exit 1;
 	}
 
+	$string .= "\n";
 	return $string;
 }
 

--- a/back-ends/gnutls28.pl
+++ b/back-ends/gnutls28.pl
@@ -193,6 +193,7 @@ sub generate_temp_policy() {
 		exit 1;
 	}
 
+	$string .= "\n";
 	return $string;
 }
 

--- a/update-crypto-policies
+++ b/update-crypto-policies
@@ -4,8 +4,9 @@ umask 022
 
 profile_dir=/usr/share/crypto-policies/
 base_dir=/etc/crypto-policies
-backend_config_dir=$base_dir/back-ends
-state_dir=$base_dir/state
+local_dir="$base_dir/local.d"
+backend_config_dir="$base_dir/back-ends"
+state_dir="$base_dir/state"
 errcode=0
 nocheck=0
 profile=''
@@ -76,9 +77,17 @@ fi
 
 echo "Setting system policy to $profile"
 for i in "$profile_dir/$profile/"*;do
-	file=$(basename "$i")
-	file=$(echo -n "$file"|sed 's/\.txt/\.config/')
-	ln -sf $i "$backend_config_dir/$file"
+	basefile=$(basename "$i")
+	file=$(echo -n "$basefile"|sed 's/\.txt/\.config/')
+	basefile=$(echo -n "$basefile"|sed 's/\.txt//')
+
+	if test -z $(ls $local_dir/$basefile*.config 2>/dev/null);then
+		ln -sf $i "$backend_config_dir/$file"
+	else
+		rm -f "$backend_config_dir/$file"
+		cat $i > "$backend_config_dir/$file"
+		cat $local_dir/$basefile-*.config >> "$backend_config_dir/$file"
+	fi
 done
 
 echo $profile > $state_dir/current

--- a/update-crypto-policies.8.txt
+++ b/update-crypto-policies.8.txt
@@ -1,5 +1,5 @@
 ////
-Copyright (C) 2014 Red Hat, Inc.
+Copyright (C) 2014-2016 Red Hat, Inc.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -133,6 +133,14 @@ FILES
 
 /etc/crypto-policies/back-ends::
 	Contains the generated policies in separated files, and in a format readable by the supported back-ends.
+
+/etc/crypto-policies/local.d::
+	Contains additional files to be appended to the generated policy
+	files. The files present must adhere to $app-XXX.config file naming, where
+	XXX is any arbitrary identifier. For example, to append a line to
+	GnuTLS' generated policy, create a gnutls-extra-line.config file in
+	local.d. This will be appended to the generated gnutls.config during
+	update-crypto-policies.
 
 AUTHOR
 ------


### PR DESCRIPTION
Currently the content of the /etc/crypto-policies/back-ends files are entirely controlled by the update-crypto-policies script. This is somewhat restrictive, for example, with gnutls the script only knows about setting the "SYSTEM" policy and is unable to set any other application specific policies.

This patch introduces support for local administrator defined extensions, to augment the content written to the back-end files. These are kept in the local.d directory in the back-end specific config format.

For example, with gnutls the administrator can now do 
```
echo "LIBVIRT=NONE:+VERS-TLS-ALL" > /etc/crypto-policies/local.d/gnutls-libvirt.config
```

And when running update-crypto-policies, this will be appended to the /etc/crypto-policies/back-ends/gnutls.config file.

Based on patch by Daniel P. Berrange 