### PR TITLE
Remove bogus trailing slash

### DIFF
--- a/update-crypto-policies
+++ b/update-crypto-policies
@@ -2,7 +2,7 @@
 
 umask 022
 
-profile_dir=/usr/share/crypto-policies/
+profile_dir=/usr/share/crypto-policies
 base_dir=/etc/crypto-policies
 local_dir="$base_dir/local.d"
 backend_config_dir="$base_dir/back-ends"


### PR DESCRIPTION
profile_dir has a trailing slash, but each of its use is finished with a slash, which leads to double slash in the symlinks:
```
$ ls -l /etc/crypto-policies/back-ends/openssh.config
lrwxrwxrwx. 1 root root 46 Sep 27 10:06 /etc/crypto-policies/back-ends/openssh.config ->
    /usr/share/crypto-policies//FUTURE/openssh.txt
```